### PR TITLE
Implement time-group feature 

### DIFF
--- a/.github/workflows/build-coq-demo.yml
+++ b/.github/workflows/build-coq-demo.yml
@@ -22,9 +22,24 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - uses: erikmd/docker-coq-action@alpha
+    - uses: erikmd/docker-coq-action@feature-timegroup
       id: docker-coq-action
       with:
         opam_file: 'coq-demo.opam'
         coq_version: '8.11'
         ocaml_version: '4.09-flambda'
+        custom_script: |
+          startGroup Print opam config
+            opam config list; opam repo list; opam list
+          endGroup
+          startGroup Fetch dependencies
+            opam pin add -n -y -k path $PACKAGE .
+            opam update -y
+          endGroup
+          startGroup Build
+            opam install -y -v -j 2 $PACKAGE
+          endGroup
+          opam list
+          startGroup Uninstallation test
+            opam remove $PACKAGE
+          endGroup

--- a/.github/workflows/build-coq-demo.yml
+++ b/.github/workflows/build-coq-demo.yml
@@ -4,12 +4,12 @@ name: CI
 
 # Controls when the action will run.
 # cf. https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#filtering-for-specific-branches-tags-and-paths
-# Triggers the workflow on all push events, or pull request events
-# only for the master branch:
+# Triggers the workflow on push events or pull request events for the
+# master branch only:
 on:
   push:
     branches:
-      - '**'
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/build-coq-demo.yml
+++ b/.github/workflows/build-coq-demo.yml
@@ -27,7 +27,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - uses: erikmd/docker-coq-action@feature-timegroup
+    - uses: erikmd/docker-coq-action@alpha
       id: docker-coq-action
       with:
         opam_file: 'coq-demo.opam'

--- a/.github/workflows/build-coq-demo.yml
+++ b/.github/workflows/build-coq-demo.yml
@@ -42,8 +42,8 @@ jobs:
           endGroup
           startGroup Build
             opam install -y -v -j 2 $PACKAGE
+            opam list
           endGroup
-          opam list
           startGroup Uninstallation test
             opam remove $PACKAGE
           endGroup

--- a/.github/workflows/build-coq-demo.yml
+++ b/.github/workflows/build-coq-demo.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         opam_file: 'coq-demo.opam'
         coq_version: '8.11'
-        ocaml_version: '4.09-flambda'
+        ocaml_version: '4.07-flambda'
         custom_script: |
           startGroup Print opam config
             opam config list; opam repo list; opam list

--- a/.github/workflows/build-coq-demo.yml
+++ b/.github/workflows/build-coq-demo.yml
@@ -18,7 +18,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
+    # The type of runner that the job will run on;
+    # the OS must be GNU/Linux to be able to use the docker-coq-action
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/build-coq-demo.yml
+++ b/.github/workflows/build-coq-demo.yml
@@ -2,13 +2,17 @@
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Controls when the action will run.
+# cf. https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#filtering-for-specific-branches-tags-and-paths
+# Triggers the workflow on all push events, or pull request events
+# only for the master branch:
 on:
   push:
-    branches: [ master ]
+    branches:
+      - '**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This implements @liyishuai 's request from:
https://github.com/coq-community/docker-coq/issues/4#issuecomment-605504196

The relevant script example (from the users perspective) is:

https://github.com/erikmd/docker-coq-github-action-demo/blob/348c4b61321a3426ab34dca953d8a47118056a4d/.github/workflows/build-coq-demo.yml#L29-L49

and the GitHub-Actions example output is [at this URL](https://github.com/erikmd/docker-coq-github-action-demo/runs/542297716?check_suite_focus=true#step:4:37).

If @Zimmi48 is OK with this feature, I'll merge the [feature-timegroup](https://github.com/erikmd/docker-coq-action/tree/feature-timegroup) branch in `docker-coq-action` as well.